### PR TITLE
Improve the formatting of comp.vote as a V3 extension

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -80,6 +80,7 @@ export default function Header() {
           </ul>
         </div>
 
+        {/* Authenticate button */}
         <div>
           {address ? (
             // If user is authenticated, show unauthenticate button

--- a/components/header.js
+++ b/components/header.js
@@ -1,4 +1,3 @@
-import { useContext } from "react";
 import Link from "next/link"; // Link routing
 import { web3p } from "containers"; // Web3 provider
 import { useRouter } from "next/router"; // Router
@@ -7,10 +6,8 @@ import styles from "styles/layout.module.scss"; // Styles
 import HamburgerMenu from "react-hamburger-menu"; // Hamburger button
 import useENS from "./hooks/useENS";
 import Davatar from "@davatar/react";
-import { Embedded } from "containers"; // Embedded
 
 export default function Header() {
-  const embedded = useContext(Embedded);
   const router = useRouter(); // Router
   const [menuOpen, setMenuOpen] = useState(false); // Mobile menu
   const { address, authenticate, unauthenticate } = web3p.useContainer(); // State from context
@@ -41,15 +38,13 @@ export default function Header() {
     };
   }, []);
 
-  const em = embedded ? "?embedded" : "";
-
   return (
     <div className={styles.header}>
       {/* Center sizer */}
       <div>
         {/* Logo */}
         <div>
-          <Link href={`/${em}`}>
+          <Link href={`/`}>
             <a>
               <img
                 src="brand/compound-logo.svg"
@@ -65,14 +60,14 @@ export default function Header() {
         <div>
           <ul>
             <li>
-              <Link href={`/${em}`}>
+              <Link href={`/`}>
                 <a className={router.pathname === "/" ? styles.active : null}>
                   Vote
                 </a>
               </Link>
             </li>
             <li>
-              <Link href={`/delegate${em}`}>
+              <Link href={`/delegate`}>
                 <a
                   className={
                     router.pathname === "/delegate" ? styles.active : null
@@ -85,102 +80,95 @@ export default function Header() {
           </ul>
         </div>
 
-        {/* Authenticate button */}
-        { embedded ? null :
-          <div>
-            {address ? (
-              // If user is authenticated, show unauthenticate button
-              <button onClick={unauthenticate}>
-                {/* User address */}
-                <span className={styles.account}>
-                  <span className={styles.davatar}>
-                    <Davatar size={24} address={address} />
-                  </span>
-                  <span>
-                    {ensName ||
-                      address.substr(0, 5) +
-                        "..." +
-                        address.slice(address.length - 5)}
-                  </span>
+        <div>
+          {address ? (
+            // If user is authenticated, show unauthenticate button
+            <button onClick={unauthenticate}>
+              {/* User address */}
+              <span className={styles.account}>
+                <span className={styles.davatar}>
+                  <Davatar size={24} address={address} />
                 </span>
-                {/* Logout icon SVG */}
-                <svg viewBox="0 0 512 512">
-                  <path d="m320 277.335938c-11.796875 0-21.332031 9.558593-21.332031 21.332031v85.335937c0 11.753906-9.558594 21.332032-21.335938 21.332032h-64v-320c0-18.21875-11.605469-34.496094-29.054687-40.554688l-6.316406-2.113281h99.371093c11.777344 0 21.335938 9.578125 21.335938 21.335937v64c0 11.773438 9.535156 21.332032 21.332031 21.332032s21.332031-9.558594 21.332031-21.332032v-64c0-35.285156-28.714843-63.99999975-64-63.99999975h-229.332031c-.8125 0-1.492188.36328175-2.28125.46874975-1.027344-.085937-2.007812-.46874975-3.050781-.46874975-23.53125 0-42.667969 19.13281275-42.667969 42.66406275v384c0 18.21875 11.605469 34.496093 29.054688 40.554687l128.386718 42.796875c4.351563 1.34375 8.679688 1.984375 13.226563 1.984375 23.53125 0 42.664062-19.136718 42.664062-42.667968v-21.332032h64c35.285157 0 64-28.714844 64-64v-85.335937c0-11.773438-9.535156-21.332031-21.332031-21.332031zm0 0" />
-                  <path d="m505.75 198.253906-85.335938-85.332031c-6.097656-6.101563-15.273437-7.9375-23.25-4.632813-7.957031 3.308594-13.164062 11.09375-13.164062 19.714844v64h-85.332031c-11.777344 0-21.335938 9.554688-21.335938 21.332032 0 11.777343 9.558594 21.332031 21.335938 21.332031h85.332031v64c0 8.621093 5.207031 16.40625 13.164062 19.714843 7.976563 3.304688 17.152344 1.46875 23.25-4.628906l85.335938-85.335937c8.339844-8.339844 8.339844-21.824219 0-30.164063zm0 0" />
-                </svg>
-              </button>
-            ) : (
-              // Else, show authenticate button
-              <button onClick={authenticate}>Connect Wallet</button>
-            )}
-          </div>
-        }
+                <span>
+                  {ensName ||
+                    address.substr(0, 5) +
+                      "..." +
+                      address.slice(address.length - 5)}
+                </span>
+              </span>
+              {/* Logout icon SVG */}
+              <svg viewBox="0 0 512 512">
+                <path d="m320 277.335938c-11.796875 0-21.332031 9.558593-21.332031 21.332031v85.335937c0 11.753906-9.558594 21.332032-21.335938 21.332032h-64v-320c0-18.21875-11.605469-34.496094-29.054687-40.554688l-6.316406-2.113281h99.371093c11.777344 0 21.335938 9.578125 21.335938 21.335937v64c0 11.773438 9.535156 21.332032 21.332031 21.332032s21.332031-9.558594 21.332031-21.332032v-64c0-35.285156-28.714843-63.99999975-64-63.99999975h-229.332031c-.8125 0-1.492188.36328175-2.28125.46874975-1.027344-.085937-2.007812-.46874975-3.050781-.46874975-23.53125 0-42.667969 19.13281275-42.667969 42.66406275v384c0 18.21875 11.605469 34.496093 29.054688 40.554687l128.386718 42.796875c4.351563 1.34375 8.679688 1.984375 13.226563 1.984375 23.53125 0 42.664062-19.136718 42.664062-42.667968v-21.332032h64c35.285157 0 64-28.714844 64-64v-85.335937c0-11.773438-9.535156-21.332031-21.332031-21.332031zm0 0" />
+                <path d="m505.75 198.253906-85.335938-85.332031c-6.097656-6.101563-15.273437-7.9375-23.25-4.632813-7.957031 3.308594-13.164062 11.09375-13.164062 19.714844v64h-85.332031c-11.777344 0-21.335938 9.554688-21.335938 21.332032 0 11.777343 9.558594 21.332031 21.335938 21.332031h85.332031v64c0 8.621093 5.207031 16.40625 13.164062 19.714843 7.976563 3.304688 17.152344 1.46875 23.25-4.628906l85.335938-85.335937c8.339844-8.339844 8.339844-21.824219 0-30.164063zm0 0" />
+              </svg>
+            </button>
+          ) : (
+            // Else, show authenticate button
+            <button onClick={authenticate}>Connect Wallet</button>
+          )}
+        </div>
 
         {/* Mobile menu hamburger button */}
-        { embedded ? null :
-          <div className={styles.mobileButton}>
-            <HamburgerMenu
-              width={20}
-              height={15}
-              color="white"
-              isOpen={menuOpen}
-              menuClicked={() => setMenuOpen((previous) => !previous)}
-            />
-          </div>
-        }
+        <div className={styles.mobileButton}>
+          <HamburgerMenu
+            width={20}
+            height={15}
+            color="white"
+            isOpen={menuOpen}
+            menuClicked={() => setMenuOpen((previous) => !previous)}
+          />
+        </div>
 
         {/* Mobile menu */}
-        { embedded ? null :
-          <div
-            className={`${styles.mobileMenu} ${
-              menuOpen ? styles.mobileMenuOpen : styles.mobileMenuHidden
-            }`}
-          >
-            <ul>
-              <li>
-                <Link href={`/${em}`}>
-                  <a>Vote</a>
-                </Link>
-              </li>
-              <li>
-                <Link href={`/delegate${em}`}>
-                  <a>Delegate</a>
-                </Link>
-              </li>
-            </ul>
-            {address ? (
-              // If user is authenticated, show unauthenticate button
-              <button
-                onClick={() => {
-                  unauthenticate();
-                  setMenuOpen(false);
-                }}
-              >
-                {/* User address */}
-                <span>
-                  {address.substr(0, 5) +
-                    "..." +
-                    address.slice(address.length - 5)}
-                </span>
-                {/* Logout icon SVG */}
-                <svg viewBox="0 0 512 512">
-                  <path d="m320 277.335938c-11.796875 0-21.332031 9.558593-21.332031 21.332031v85.335937c0 11.753906-9.558594 21.332032-21.335938 21.332032h-64v-320c0-18.21875-11.605469-34.496094-29.054687-40.554688l-6.316406-2.113281h99.371093c11.777344 0 21.335938 9.578125 21.335938 21.335937v64c0 11.773438 9.535156 21.332032 21.332031 21.332032s21.332031-9.558594 21.332031-21.332032v-64c0-35.285156-28.714843-63.99999975-64-63.99999975h-229.332031c-.8125 0-1.492188.36328175-2.28125.46874975-1.027344-.085937-2.007812-.46874975-3.050781-.46874975-23.53125 0-42.667969 19.13281275-42.667969 42.66406275v384c0 18.21875 11.605469 34.496093 29.054688 40.554687l128.386718 42.796875c4.351563 1.34375 8.679688 1.984375 13.226563 1.984375 23.53125 0 42.664062-19.136718 42.664062-42.667968v-21.332032h64c35.285157 0 64-28.714844 64-64v-85.335937c0-11.773438-9.535156-21.332031-21.332031-21.332031zm0 0" />
-                  <path d="m505.75 198.253906-85.335938-85.332031c-6.097656-6.101563-15.273437-7.9375-23.25-4.632813-7.957031 3.308594-13.164062 11.09375-13.164062 19.714844v64h-85.332031c-11.777344 0-21.335938 9.554688-21.335938 21.332032 0 11.777343 9.558594 21.332031 21.335938 21.332031h85.332031v64c0 8.621093 5.207031 16.40625 13.164062 19.714843 7.976563 3.304688 17.152344 1.46875 23.25-4.628906l85.335938-85.335937c8.339844-8.339844 8.339844-21.824219 0-30.164063zm0 0" />
-                </svg>
-              </button>
-            ) : (
-              // Else, show authenticate button
-              <button
-                onClick={() => {
-                  authenticate();
-                  setMenuOpen(false);
-                }}
-              >
-                Connect Wallet
-              </button>
-            )}
-          </div>
-        }
+        <div
+          className={`${styles.mobileMenu} ${
+            menuOpen ? styles.mobileMenuOpen : styles.mobileMenuHidden
+          }`}
+        >
+          <ul>
+            <li>
+              <Link href={`/`}>
+                <a>Vote</a>
+              </Link>
+            </li>
+            <li>
+              <Link href={`/delegate`}>
+                <a>Delegate</a>
+              </Link>
+            </li>
+          </ul>
+          {address ? (
+            // If user is authenticated, show unauthenticate button
+            <button
+              onClick={() => {
+                unauthenticate();
+                setMenuOpen(false);
+              }}
+            >
+              {/* User address */}
+              <span>
+                {address.substr(0, 5) +
+                  "..." +
+                  address.slice(address.length - 5)}
+              </span>
+              {/* Logout icon SVG */}
+              <svg viewBox="0 0 512 512">
+                <path d="m320 277.335938c-11.796875 0-21.332031 9.558593-21.332031 21.332031v85.335937c0 11.753906-9.558594 21.332032-21.335938 21.332032h-64v-320c0-18.21875-11.605469-34.496094-29.054687-40.554688l-6.316406-2.113281h99.371093c11.777344 0 21.335938 9.578125 21.335938 21.335937v64c0 11.773438 9.535156 21.332032 21.332031 21.332032s21.332031-9.558594 21.332031-21.332032v-64c0-35.285156-28.714843-63.99999975-64-63.99999975h-229.332031c-.8125 0-1.492188.36328175-2.28125.46874975-1.027344-.085937-2.007812-.46874975-3.050781-.46874975-23.53125 0-42.667969 19.13281275-42.667969 42.66406275v384c0 18.21875 11.605469 34.496093 29.054688 40.554687l128.386718 42.796875c4.351563 1.34375 8.679688 1.984375 13.226563 1.984375 23.53125 0 42.664062-19.136718 42.664062-42.667968v-21.332032h64c35.285157 0 64-28.714844 64-64v-85.335937c0-11.773438-9.535156-21.332031-21.332031-21.332031zm0 0" />
+                <path d="m505.75 198.253906-85.335938-85.332031c-6.097656-6.101563-15.273437-7.9375-23.25-4.632813-7.957031 3.308594-13.164062 11.09375-13.164062 19.714844v64h-85.332031c-11.777344 0-21.335938 9.554688-21.335938 21.332032 0 11.777343 9.558594 21.332031 21.335938 21.332031h85.332031v64c0 8.621093 5.207031 16.40625 13.164062 19.714843 7.976563 3.304688 17.152344 1.46875 23.25-4.628906l85.335938-85.335937c8.339844-8.339844 8.339844-21.824219 0-30.164063zm0 0" />
+              </svg>
+            </button>
+          ) : (
+            // Else, show authenticate button
+            <button
+              onClick={() => {
+                authenticate();
+                setMenuOpen(false);
+              }}
+            >
+              Connect Wallet
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,15 +1,57 @@
 import axios from "axios"; // Requests wrapper
 import dayjs from "dayjs"; // Dayjs
-import { useState } from "react"; // State management
+import { useContext, useState } from "react"; // State management
 import Layout from "components/layout"; // Layout wrapper
 import APICTA from "components/api_cta"; // API CTA
 import { web3p, vote } from "containers"; // Context
 import styles from "styles/page.module.scss"; // Page styles
 import BeatLoader from "react-spinners/BeatLoader"; // Loading state
+import { Embedded } from "containers"; // Embedded
 
-export default function Home({ defaultProposals, defaultPages }) {
+
+export default function Home(props) {
+  const [pages, setPages] = useState(props.defaultPages); // Proposal pagination
+  const embedded = useContext(Embedded);
+
+  const pageContent = <VoteContent {...props} pages={pages} setPages={setPages} />;
+  if (embedded) {
+    // Don't wrap the content when embedded.
+    return pageContent;
+  }
+
+  return (
+    <Layout>
+      {/* Page head */}
+      <div className={styles.head}>
+        <div>
+          {/* Description of voting by signature */}
+          <h1>Vote By Signature</h1>
+          <div>
+            <p>
+              Voting by signature lets you place votes across Compound Governance
+              proposals, without having to send your transactions on-chain,
+              saving fees.
+            </p>
+          </div>
+
+          {/* Number of voteable proposals */}
+          <div>
+            <h2>{pages.entries}</h2>
+            <h3>Total Proposals</h3>
+          </div>
+        </div>
+      </div>
+      <div className={styles.body}>
+        <VoteContent {...props} pages={pages} setPages={setPages} />
+        {/* Swagger API CTA card */}
+        <APICTA />
+      </div>
+    </Layout>
+  )
+}
+
+function VoteContent({ defaultProposals, pages, setPages }) {
   const [loading, setLoading] = useState(false); // Proposal loading state
-  const [pages, setPages] = useState(defaultPages); // Proposal pagination
   const [proposals, setProposals] = useState(defaultProposals); // Proposals array
   const [buttonLoading, setButtonLoading] = useState({ id: null, type: null }); // Current button loading state
 
@@ -98,149 +140,120 @@ export default function Home({ defaultProposals, defaultPages }) {
   };
 
   return (
-    <Layout>
-      {/* Page head */}
-      <div className={styles.head}>
+    <div>
+      {/* Recent proposals card */}
+      <div className={styles.card}>
+        {/* Card header */}
         <div>
-          {/* Description of voting by signature */}
-          <h1>Vote By Signature</h1>
-          <div>
-            <p>
-              Voting by signature lets you place votes across Compound Governance
-              proposals, without having to send your transactions on-chain,
-              saving fees.
-            </p>
-          </div>
-
-          {/* Number of voteable proposals */}
-          <div>
-            <h2>{pages.entries}</h2>
-            <h3>Total Proposals</h3>
-          </div>
+          <h4>Recent Proposals</h4>
         </div>
-      </div>
 
-      {/* Page body */}
-      <div className={styles.body}>
+        {/* Card proposals */}
         <div>
-          {/* Recent proposals card */}
-          <div className={styles.card}>
-            {/* Card header */}
-            <div>
-              <h4>Recent Proposals</h4>
-            </div>
+          {proposals.map((proposal, i) => {
+            // For each proposal in proposals array return:
+            return (
+              <div className={styles.proposal} key={i}>
+                {/* Proposal info */}
+                <div>
+                  {/* Truncated proposal name */}
+                  <h4>
+                    {proposal.title.split(" ").splice(0, 10).join(" ")}
+                    {proposal.title.split(" ").length > 10 ? "..." : ""}
+                  </h4>
 
-            {/* Card proposals */}
-            <div>
-              {proposals.map((proposal, i) => {
-                // For each proposal in proposals array return:
-                return (
-                  <div className={styles.proposal} key={i}>
-                    {/* Proposal info */}
-                    <div>
-                      {/* Truncated proposal name */}
-                      <h4>
-                        {proposal.title.split(" ").splice(0, 10).join(" ")}
-                        {proposal.title.split(" ").length > 10 ? "..." : ""}
-                      </h4>
+                  {/* Proposal ID + Status + Status update date */}
+                  <span>
+                    {proposal.id} •{" "}
+                    {firstUppercase(
+                      proposal.states[proposal.states.length - 1].state
+                    )}{" "}
+                    {dayjs
+                      .unix(
+                        proposal.states[proposal.states.length - 1]
+                          .start_time
+                      )
+                      .format("MMMM D, YYYY")}
+                  </span>
+                </div>
 
-                      {/* Proposal ID + Status + Status update date */}
-                      <span>
-                        {proposal.id} •{" "}
-                        {firstUppercase(
-                          proposal.states[proposal.states.length - 1].state
-                        )}{" "}
-                        {dayjs
-                          .unix(
-                            proposal.states[proposal.states.length - 1]
-                              .start_time
-                          )
-                          .format("MMMM D, YYYY")}
-                      </span>
-                    </div>
-
-                    {/* Proposal actions */}
-                    <div>
+                {/* Proposal actions */}
+                <div>
+                  <button
+                    onClick={() => proposalInfo(proposal.id)}
+                    className={styles.info}
+                  >
+                    Info
+                  </button>
+                  {proposal.states[proposal.states.length - 1].state ===
+                  "active" ? (
+                    // Check if proposal is active
+                    web3 ? (
+                      // If authenticated and proposal active, return voting + info buttons
+                      <>
+                        <button
+                          onClick={() => voteWithLoading(proposal.id, 0)}
+                          className={styles.for}
+                        >
+                          {buttonLoading.id === proposal.id &&
+                          buttonLoading.type === 0 ? (
+                            <BeatLoader size={9} />
+                          ) : (
+                            "Vote For"
+                          )}
+                        </button>
+                        <button
+                          onClick={() => voteWithLoading(proposal.id, 1)}
+                          className={styles.against}
+                        >
+                          {buttonLoading.id === proposal.id &&
+                          buttonLoading.type === 1 ? (
+                            <BeatLoader size={9} />
+                          ) : (
+                            "Vote Against"
+                          )}
+                        </button>
+                        <button
+                          onClick={() => voteWithLoading(proposal.id, 2)}
+                          className={styles.abstain}
+                        >
+                          {buttonLoading.id === proposal.id &&
+                          buttonLoading.type === 2 ? (
+                            <BeatLoader size={9} />
+                          ) : (
+                            "Abstain"
+                          )}
+                        </button>
+                      </>
+                    ) : (
+                      // Else, return button to authenticate for active proposals
                       <button
-                        onClick={() => proposalInfo(proposal.id)}
                         className={styles.info}
+                        onClick={authenticate}
                       >
-                        Info
+                        Authenticate to vote
                       </button>
-                      {proposal.states[proposal.states.length - 1].state ===
-                      "active" ? (
-                        // Check if proposal is active
-                        web3 ? (
-                          // If authenticated and proposal active, return voting + info buttons
-                          <>
-                            <button
-                              onClick={() => voteWithLoading(proposal.id, 0)}
-                              className={styles.for}
-                            >
-                              {buttonLoading.id === proposal.id &&
-                              buttonLoading.type === 0 ? (
-                                <BeatLoader size={9} />
-                              ) : (
-                                "Vote For"
-                              )}
-                            </button>
-                            <button
-                              onClick={() => voteWithLoading(proposal.id, 1)}
-                              className={styles.against}
-                            >
-                              {buttonLoading.id === proposal.id &&
-                              buttonLoading.type === 1 ? (
-                                <BeatLoader size={9} />
-                              ) : (
-                                "Vote Against"
-                              )}
-                            </button>
-                            <button
-                              onClick={() => voteWithLoading(proposal.id, 2)}
-                              className={styles.abstain}
-                            >
-                              {buttonLoading.id === proposal.id &&
-                              buttonLoading.type === 2 ? (
-                                <BeatLoader size={9} />
-                              ) : (
-                                "Abstain"
-                              )}
-                            </button>
-                          </>
-                        ) : (
-                          // Else, return button to authenticate for active proposals
-                          <button
-                            className={styles.info}
-                            onClick={authenticate}
-                          >
-                            Authenticate to vote
-                          </button>
-                        )
-                      ) : // Else, return only Info button
-                      null}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-
-            {/* More proposals loading button */}
-            {pages.current < pages.max ? (
-              // If current number of pages < max, show:
-              <div className={styles.cardMore}>
-                {/* Load more proposals button */}
-                <button onClick={getNextPage} disabled={loading}>
-                  {loading ? "Loading..." : "Load More Proposals"}
-                </button>
+                    )
+                  ) : // Else, return only Info button
+                  null}
+                </div>
               </div>
-            ) : null}
-          </div>
+            );
+          })}
         </div>
 
-        {/* Swagger API CTA card */}
-        <APICTA />
+        {/* More proposals loading button */}
+        {pages.current < pages.max ? (
+          // If current number of pages < max, show:
+          <div className={styles.cardMore}>
+            {/* Load more proposals button */}
+            <button onClick={getNextPage} disabled={loading}>
+              {loading ? "Loading..." : "Load More Proposals"}
+            </button>
+          </div>
+        ) : null}
       </div>
-    </Layout>
+    </div>
   );
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,10 +13,10 @@ export default function Home(props) {
   const [pages, setPages] = useState(props.defaultPages); // Proposal pagination
   const embedded = useContext(Embedded);
 
-  const pageContent = <VoteContent {...props} pages={pages} setPages={setPages} />;
+  const proposalsContent = <ProposalsContent {...props} pages={pages} setPages={setPages} />;
   if (embedded) {
     // Don't wrap the content when embedded.
-    return pageContent;
+    return proposalsContent;
   }
 
   return (
@@ -42,7 +42,7 @@ export default function Home(props) {
         </div>
       </div>
       <div className={styles.body}>
-        <VoteContent {...props} pages={pages} setPages={setPages} />
+        {proposalsContent}
         {/* Swagger API CTA card */}
         <APICTA />
       </div>
@@ -50,7 +50,7 @@ export default function Home(props) {
   )
 }
 
-function VoteContent({ defaultProposals, pages, setPages }) {
+function ProposalsContent({ defaultProposals, pages, setPages }) {
   const [loading, setLoading] = useState(false); // Proposal loading state
   const [proposals, setProposals] = useState(defaultProposals); // Proposals array
   const [buttonLoading, setButtonLoading] = useState({ id: null, type: null }); // Current button loading state


### PR DESCRIPTION
Currently as an extension, the comp.vote header looks a bit redundant with the built-in header we provide for all extensions.
We think it may look a lot cleaner to remove the header when comp.vote is embedded as an extension. Unfortunately this means that `Delegate` is no longer navigable within the extension itself, but think it's probably worth the tradeoff, since the main utility of the comp.vote extension is to be able to vote in a gas-less way, over infrequent savings of ~$1 on the delegate functionality. We can instead, have users go to the comp.vote app if they do want to delegate in a gas-less way.

Would appreciate any thoughts/feedback!

Before:
<img width="1272" alt="image" src="https://user-images.githubusercontent.com/15851351/206553018-1a27c753-44a0-43f6-8866-429d45698023.png">

After:
<img width="1409" alt="image" src="https://user-images.githubusercontent.com/15851351/206554125-3f21f413-fda7-4f70-818c-05a8301e18f8.png">